### PR TITLE
Add telescope diff support

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,6 +44,10 @@ not reliable and quick enough, so I decided to add this
 dependency. The extension will still work without it, =purge= just won't do
 anything.
 
+If you want tree-sitter highlighting while viewing diffs, make sure to =:TSInstall diff=
+and add [[https://github.com/nvim-treesitter/nvim-treesitter][nvim-treesitter]] as a
+dependency.
+
 
 ** Installation and Configuration
 

--- a/lua/telescope/_extensions/file_history.lua
+++ b/lua/telescope/_extensions/file_history.lua
@@ -35,7 +35,14 @@ local preview_file_history = function(opts, bufnr)
         local diff = vim.diff(table.concat(buffer_lines, '\n'), table.concat(parent_lines, '\n'),
         { result_type = 'unified', ctxlen = 3 })
         vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, true, split(diff, '\n'))
-        putils.regex_highlighter(self.state.bufnr, "diff")
+
+        local parser = "diff"
+
+        if vim.tbl_contains(require("nvim-treesitter.info").installed_parsers(), parser) then
+          vim.treesitter.start(self.state.bufnr, parser)
+        else
+          putils.regex_highlighter(self.state.bufnr, "diff")
+        end
       end
     end,
   })

--- a/lua/telescope/_extensions/file_history.lua
+++ b/lua/telescope/_extensions/file_history.lua
@@ -18,6 +18,21 @@ local function split(str, sep)
   return result
 end
 
+--- Parse and add syntax highlighting to `bufnr`.
+---
+--- @param number A 0-or-more value indicating the Neovim buffer to add highlighting.
+---
+local function apply_diff_syntax_highlighting(bufnr)
+  local parser = "diff"
+
+  if vim.tbl_contains(require("nvim-treesitter.info").installed_parsers(), parser) then
+    vim.treesitter.start(bufnr, parser)
+  else
+    putils.regex_highlighter(bufnr, "diff")
+  end
+end
+
+
 local preview_file_history = function(opts, bufnr)
   return previewers.new_buffer_previewer({
     title = "File History",
@@ -28,21 +43,14 @@ local preview_file_history = function(opts, bufnr)
       if opts.log then
         local diff = fh.get_log(entry.fields.file, entry.fields.hash)
         vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, true, diff)
-        putils.regex_highlighter(self.state.bufnr, "diff")
+        apply_diff_syntax_highlighting(self.state.bufnr)
       else
         local buffer_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
         local parent_lines = fh.get_file(entry.fields.file, entry.fields.hash)
         local diff = vim.diff(table.concat(buffer_lines, '\n'), table.concat(parent_lines, '\n'),
         { result_type = 'unified', ctxlen = 3 })
         vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, true, split(diff, '\n'))
-
-        local parser = "diff"
-
-        if vim.tbl_contains(require("nvim-treesitter.info").installed_parsers(), parser) then
-          vim.treesitter.start(self.state.bufnr, parser)
-        else
-          putils.regex_highlighter(self.state.bufnr, "diff")
-        end
+        apply_diff_syntax_highlighting(self.state.bufnr)
       end
     end,
   })


### PR DESCRIPTION
Hi, I just started using your plugin today and am enjoying it. I wrote an old plugin to do a global git backup https://github.com/ColinKennedy/vim-git-backup but it's a bit slow, doesn't work on Windows, and has no interactivity. I found your plugin and got excited to try it!

This is minor but the highlighting could be a bit better depending on the colorscheme. I added tree-sitter support which I thought gives a good out of box experience for those colorschemes.

## Summary
Adds optional tree-sitter parsing (and highlights) if available. Regex can be used as a fallback.

## Before
![telescope-file-history nvim_before_highlights](https://github.com/dawsers/telescope-file-history.nvim/assets/10103049/b50b4322-ddf2-4665-8484-b331e6f9dc0c)

## After
![telescope-file-history nvim_after_highlights](https://github.com/dawsers/telescope-file-history.nvim/assets/10103049/da407fa8-eb8d-4c3c-a45d-33f4629c7a1d)